### PR TITLE
Fix issue with "auto_set_repository" bareword in Makerfile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,5 +29,4 @@ build_requires 'Test::MockObject';
 build_requires 'Test::MockModule';
 build_requires 'Test::Exception';
 
-auto_set_repository;
 WriteAll;


### PR DESCRIPTION
I get the following error after 'perl Makefile.PL' command:

dboys@team:~/build/perl/Net_Google_DataAPI$ perl Makefile.PL 
include /home/dboys/build/perl/Net_Google_DataAPI/inc/Module/Install.pm
Bareword "auto_set_repository" not allowed while "strict subs" in use at Makefile.PL line 32.
Execution of Makefile.PL aborted due to compilation errors.

Explanation and more details you can find here:
https://rt.cpan.org/Public/Bug/Display.html?id=76224
https://rt.cpan.org/Public/Bug/Display.html?id=76035